### PR TITLE
use clone(for_test=True) replace get_inference_program

### DIFF
--- a/__resnet30/model.py
+++ b/__resnet30/model.py
@@ -97,11 +97,7 @@ def train(batch_size, device, pass_num, iterations):
     accuracy = fluid.average.WeightedAverage()
 
     # inference program
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        # test_target = accuracy.metrics + accuracy.states
-        target_vars=[batch_acc, batch_size_tensor]
-        inference_program = fluid.io.get_inference_program(target_vars)
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     # Optimization
     optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)

--- a/__resnet50_paddle_cloud_dist/fluid/resnet.py
+++ b/__resnet50_paddle_cloud_dist/fluid/resnet.py
@@ -190,10 +190,7 @@ def get_model(args):
         avg_cost = fluid.layers.mean(x=cost)
         batch_acc = fluid.layers.accuracy(input=predict, label=label)
 
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc])
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
 

--- a/__vgg16_aws_dist/fluid_benchmark_for_aws/models/resnet.py
+++ b/__vgg16_aws_dist/fluid_benchmark_for_aws/models/resnet.py
@@ -141,10 +141,7 @@ def get_model(args):
     batch_acc = fluid.layers.accuracy(
         input=predict, label=label, total=batch_size_tensor)
 
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc, batch_size_tensor])
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
 

--- a/__vgg16_aws_dist/fluid_benchmark_for_aws/models/stacked_dynamic_lstm.py
+++ b/__vgg16_aws_dist/fluid_benchmark_for_aws/models/stacked_dynamic_lstm.py
@@ -105,10 +105,7 @@ def get_model(args):
     batch_acc = fluid.layers.accuracy(input=logit, label=fluid.layers.data(name='label', \
                 shape=[1], dtype='int64'), total=batch_size_tensor)
 
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc, batch_size_tensor])
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     adam = fluid.optimizer.Adam()
 

--- a/__vgg16_aws_dist/fluid_benchmark_for_aws/models/vgg.py
+++ b/__vgg16_aws_dist/fluid_benchmark_for_aws/models/vgg.py
@@ -81,10 +81,7 @@ def get_model(args):
         input=predict, label=label, total=batch_size_tensor)
 
     # inference program
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc, batch_size_tensor])
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     # Optimization
     optimizer = fluid.optimizer.Adam(learning_rate=args.learning_rate)

--- a/lstm/model.py
+++ b/lstm/model.py
@@ -158,11 +158,6 @@ def main():
     batch_acc = fluid.layers.accuracy(input=logit, label=fluid.layers.data(name='label', \
                 shape=[1], dtype='int64'), total=batch_size_tensor)
 
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc, batch_size_tensor])
-
     adam = fluid.optimizer.Adam()
     adam.minimize(loss)
 

--- a/mnist/model.py
+++ b/mnist/model.py
@@ -128,10 +128,7 @@ def run_benchmark(model, args):
         input=predict, label=label, total=batch_size_tensor)
 
     # inference program
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc, batch_size_tensor])
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     # Optimization
     opt = fluid.optimizer.AdamOptimizer(

--- a/resnet50/model.py
+++ b/resnet50/model.py
@@ -212,10 +212,7 @@ def run_benchmark(model, args):
     batch_acc = fluid.layers.accuracy(
         input=predict, label=label, total=batch_size_tensor)
 
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc, batch_size_tensor])
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
     opts = optimizer.minimize(avg_cost)

--- a/resnet50_net_CPU/train.py
+++ b/resnet50_net_CPU/train.py
@@ -216,10 +216,7 @@ def run_benchmark(model, args):
     batch_acc = fluid.layers.accuracy(
         input=predict, label=label, total=batch_size_tensor)
 
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc, batch_size_tensor])
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
     opts = optimizer.minimize(avg_cost)

--- a/sequence_tagging_for_ner/train.py
+++ b/sequence_tagging_for_ner/train.py
@@ -64,10 +64,7 @@ def main(train_data_file, test_data_file, vocab_file, target_file, emb_file,
         chunk_scheme="IOB",
         num_chunk_types=int(math.ceil((label_dict_len - 1) / 2.0)))
 
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        test_target = chunk_evaluator.metrics + chunk_evaluator.states
-        inference_program = fluid.io.get_inference_program(test_target)
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     train_reader = paddle.batch(
             reader.data_reader(train_data_file, word_dict, label_dict),

--- a/transformer/infer.py
+++ b/transformer/infer.py
@@ -286,10 +286,8 @@ def main():
     fluid.io.load_vars(exe, InferTaskConfig.model_path, vars=decoder_params)
 
     # This is used here to set dropout to the test mode.
-    encoder_program = fluid.io.get_inference_program(
-        target_vars=[enc_output], main_program=encoder_program)
-    decoder_program = fluid.io.get_inference_program(
-        target_vars=[predict], main_program=decoder_program)
+    encoder_program = encoder_program.clone(for_test=True)
+    decoder_program = decoder_program.clone(for_test=True)
 
     test_data = paddle.batch(
         paddle.dataset.wmt16.test(ModelHyperParams.src_vocab_size,

--- a/transformer/train.py
+++ b/transformer/train.py
@@ -179,9 +179,7 @@ def main():
         batch_size=TrainTaskConfig.batch_size)
 
     # Program to do validation.
-    test_program = fluid.default_main_program().clone()
-    with fluid.program_guard(test_program):
-        test_program = fluid.io.get_inference_program([avg_cost])
+    test_program = fluid.default_main_program().clone(for_test=True)
     val_data = paddle.batch(
         paddle.dataset.wmt16.validation(ModelHyperParams.src_vocab_size,
                                         ModelHyperParams.trg_vocab_size),

--- a/vgg16/model.py
+++ b/vgg16/model.py
@@ -130,10 +130,7 @@ def main():
         input=predict, label=label, total=batch_size_tensor)
 
     # inference program
-    inference_program = fluid.default_main_program().clone()
-    with fluid.program_guard(inference_program):
-        inference_program = fluid.io.get_inference_program(
-            target_vars=[batch_acc, batch_size_tensor])
+    inference_program = fluid.default_main_program().clone(for_test=True)
 
     # Optimization
     optimizer = fluid.optimizer.Adam(learning_rate=args.learning_rate)


### PR DESCRIPTION
Since `get_inference_program` API will be deprecated in Paddle repo, `use clone(for_test=True)` replace `get_inference_program`.