### PR TITLE
Remove deprecated fluid.memory_optimize

### DIFF
--- a/ce_models/__resnet30/model.py
+++ b/ce_models/__resnet30/model.py
@@ -102,7 +102,6 @@ def train(batch_size, device, pass_num, iterations):
     # Optimization
     optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
     opts = optimizer.minimize(avg_cost)
-    fluid.memory_optimize(fluid.default_main_program())
 
     train_reader = paddle.batch(
         paddle.dataset.cifar.train10(), batch_size=batch_size)

--- a/ce_models/__resnet50_paddle_cloud_dist/fluid/args.py
+++ b/ce_models/__resnet50_paddle_cloud_dist/fluid/args.py
@@ -87,10 +87,6 @@ def parse_args():
         action='store_true',
         help='If set, do not test the testset during training.')
     parser.add_argument(
-        '--memory_optimize',
-        action='store_true',
-        help='If set, optimize runtime memory before start.')
-    parser.add_argument(
         '--use_fake_data',
         action='store_true',
         help='If set ommit the actual read data operators.')

--- a/ce_models/__resnet50_paddle_cloud_dist/fluid/fluid_benchmark.py
+++ b/ce_models/__resnet50_paddle_cloud_dist/fluid/fluid_benchmark.py
@@ -350,8 +350,6 @@ def main():
     train_args.append(args)
     # Run optimizer.minimize(avg_loss)
     train_args[2].minimize(train_args[0])
-    if args.memory_optimize:
-        fluid.memory_optimize(fluid.default_main_program())
 
     if args.update_method == "pserver":
         train_prog, startup_prog = dist_transpile(trainer_id, args)

--- a/ce_models/__vgg16_aws_dist/fluid_benchmark_for_aws/fluid_benchmark.py
+++ b/ce_models/__vgg16_aws_dist/fluid_benchmark_for_aws/fluid_benchmark.py
@@ -95,10 +95,6 @@ def parse_args():
         action='store_false',
         help='If set, test the testset during training.')
     parser.add_argument(
-        '--memory_optimize',
-        action='store_true',
-        help='If set, optimize runtime memory before start.')
-    parser.add_argument(
         '--use_fake_data',
         action='store_true',
         help='If set ommit the actual read data operators.')
@@ -436,8 +432,6 @@ def main():
     train_args.append(args)
     # Run optimizer.minimize(avg_loss)
     train_args[2].minimize(train_args[0])
-    if args.memory_optimize:
-        fluid.memory_optimize(fluid.default_main_program())
 
     if args.update_method == "pserver":
         train_prog, startup_prog = dist_transpile(trainer_id)

--- a/ce_models/image_classification/train.py
+++ b/ce_models/image_classification/train.py
@@ -23,7 +23,6 @@ parser = argparse.ArgumentParser(description=__doc__)
 add_arg = functools.partial(add_arguments, argparser=parser)
 add_arg('batch_size',   int,  256, "Minibatch size.")
 add_arg('num_layers',   int,  50,  "How many layers for SE-ResNeXt model.")
-add_arg('with_mem_opt', bool, True, "Whether to use memory optimization or not.")
 add_arg('parallel_exe', bool, True, "Whether to use ParallelExecutor to train or not.")
 add_arg('init_model', str, None, "Whether to use initialized model.")
 add_arg('pretrained_model', str, None, "Whether to use pretrained model.")
@@ -98,9 +97,6 @@ def train_parallel_exe(args,
             regularization=fluid.regularizer.L2Decay(1e-4))
 
     opts = optimizer.minimize(avg_cost)
-
-    if args.with_mem_opt:
-        fluid.memory_optimize(fluid.default_main_program())
 
     place = fluid.CUDAPlace(0)
     exe = fluid.Executor(place)

--- a/ce_models/lstm/model.py
+++ b/ce_models/lstm/model.py
@@ -161,8 +161,6 @@ def main():
     adam = fluid.optimizer.Adam()
     adam.minimize(loss)
 
-    fluid.memory_optimize(fluid.default_main_program())
-
     place = fluid.CPUPlace() if args.device == 'CPU' else fluid.CUDAPlace(0)
     exe = fluid.Executor(place)
     exe.run(fluid.default_startup_program())

--- a/ce_models/mnist/model.py
+++ b/ce_models/mnist/model.py
@@ -135,8 +135,6 @@ def run_benchmark(model, args):
         learning_rate=0.001, beta1=0.9, beta2=0.999)
     opt.minimize(avg_cost)
 
-    fluid.memory_optimize(fluid.default_main_program())
-
     # Initialize executor
     place = fluid.CPUPlace() if args.device == 'CPU' else fluid.CUDAPlace(0)
     exe = fluid.Executor(place)

--- a/ce_models/resnet50_net_CPU/train.py
+++ b/ce_models/resnet50_net_CPU/train.py
@@ -234,8 +234,6 @@ def run_benchmark(model, args):
     optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
     opts = optimizer.minimize(avg_cost)
 
-    fluid.memory_optimize(fluid.default_main_program())
-
     # Init ParallelExecutor
     train_exe, test_exe = get_parallel_executor(args, avg_cost,
                                                 fluid.default_main_program(),

--- a/ce_models/seq2seq/model.py
+++ b/ce_models/seq2seq/model.py
@@ -279,8 +279,6 @@ def train():
     optimizer = fluid.optimizer.Adam(learning_rate=args.learning_rate)
     optimizer.minimize(avg_cost)
 
-    fluid.memory_optimize(fluid.default_main_program())
-
     train_batch_generator = paddle.batch(
         paddle.reader.shuffle(
             paddle.dataset.wmt14.train(args.dict_size), buf_size=1000),

--- a/ce_models/vgg16/model.py
+++ b/ce_models/vgg16/model.py
@@ -136,8 +136,6 @@ def main():
     optimizer = fluid.optimizer.Adam(learning_rate=args.learning_rate)
     opts = optimizer.minimize(avg_cost)
 
-    fluid.memory_optimize(fluid.default_main_program())
-
     # Initialize executor
     place = core.CPUPlace() if args.device == 'CPU' else core.CUDAPlace(0)
     exe = fluid.Executor(place)


### PR DESCRIPTION
Interface `fluid.memory_optimize` has been deprecated in Paddle since [PR18983](https://github.com/PaddlePaddle/Paddle/pull/18983).

So this PR try to remove all usages of empty interface `fluid.memory_optimize` in models.